### PR TITLE
NET 9 compiler fixes for netstandard 1.x

### DIFF
--- a/NET/Bankinfrastruktur.Data/Bankinfrastruktur.Data.csproj
+++ b/NET/Bankinfrastruktur.Data/Bankinfrastruktur.Data.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.2;netstandard2.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.2;netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <CheckNotRecommendedTargetFramework>false</CheckNotRecommendedTargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>Bankinfrastruktur;Swedishbankers;clearingnummer;bankkonto;BIC;IBAN</PackageTags>
     <Description>Datacollection for how to validate Swedish bank accounts as well as BIC and IBAN details. Sammanställning av data i maskinläsbart format från Bankgirot och Bankinfrastruktur (BSAB)</Description>
@@ -82,6 +83,13 @@ File.SetLastWriteTimeUtc(fi.FullName, File.GetLastWriteTimeUtc(srcFi.FullName));
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="*" PrivateAssets="All"/>
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework) == 'netstandard1.2' ">
+    <!-- https://github.com/advisories/GHSA-7jgj-8wvc-jh57 -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <!-- https://github.com/advisories/GHSA-cmhx-cq75-c4mj -->
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NET 9 compiler introduces warnings for netstandard 1.x upgrade specific packages and ignore netstandard 1.2 warnings Switch from net7.0 (out of support) to net8.0
Keep net6.0 for legacy support and working with net7.0